### PR TITLE
Modernized the Haxe React Route Lib

### DIFF
--- a/src/react/router/IndexLink.hx
+++ b/src/react/router/IndexLink.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'IndexLink')
+#if (jsImport)
+@:js.import('react-router-dom', 'IndexLink')
+#else
+@:jsRequire('react-router-dom', 'IndexLink')
+#end
 extern class IndexLink extends react.ReactComponent {}

--- a/src/react/router/IndexRedirect.hx
+++ b/src/react/router/IndexRedirect.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'IndexRedirect')
+#if (jsImport)
+@:js.import('react-router-dom', 'IndexRedirect')
+#else
+@:jsRequire('react-router-dom', 'IndexRedirect')
+#end
 extern class IndexRedirect extends react.ReactComponent {}

--- a/src/react/router/IndexRoute.hx
+++ b/src/react/router/IndexRoute.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'IndexRoute')
+#if (jsImport)
+@:js.import('react-router-dom', 'IndexRoute')
+#else
+@:jsRequire('react-router-dom', 'IndexRoute')
+#end
 extern class IndexRoute extends react.ReactComponent {}

--- a/src/react/router/Link.hx
+++ b/src/react/router/Link.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router','Link')
+#if (jsImport)
+@:js.import('react-router-dom', 'Link')
+#else
+@:jsRequire('react-router-dom', 'Link')
+#end
 extern class Link extends react.ReactComponent {}

--- a/src/react/router/Redirect.hx
+++ b/src/react/router/Redirect.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'Redirect')
+#if (jsImport)
+@:js.import('react-router-dom', 'Redirect')
+#else
+@:jsRequire('react-router-dom', 'Redirect')
+#end
 extern class Redirect extends react.ReactComponent {}

--- a/src/react/router/Route.hx
+++ b/src/react/router/Route.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'Route')
+#if (jsImport)
+@:js.import('react-router-dom', 'Route')
+#else
+@:jsRequire('react-router-dom', 'Route')
+#end
 extern class Route extends react.ReactComponent {}

--- a/src/react/router/Router.hx
+++ b/src/react/router/Router.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'Router')
+#if (jsImport)
+@:js.import('react-router-dom', 'Router')
+#else
+@:jsRequire('react-router-dom', 'Router')
+#end
 extern class Router extends react.ReactComponent {}

--- a/src/react/router/RouterContext.hx
+++ b/src/react/router/RouterContext.hx
@@ -1,4 +1,8 @@
 package react.router;
 
-@:jsRequire('react-router', 'RouterContext')
+#if (jsImport)
+@:js.import('react-router-dom', 'RouterContext')
+#else
+@:jsRequire('react-router-dom', 'RouterContext')
+#end
 extern class RouterContext extends react.ReactComponent {}

--- a/src/react/router/Statics.hx
+++ b/src/react/router/Statics.hx
@@ -2,7 +2,11 @@ package react.router;
 
 import react.router.Types;
 
-@:jsRequire('react-router')
+#if (jsImport)
+@:js.import(@default 'react-router-dom')
+#else
+@:jsRequire('react-router-dom')
+#end
 extern class Statics {
 	static public var hashHistory:HashHistory;
 	static public var browserHistory:BrowserHistory;

--- a/src/react/router/Types.hx
+++ b/src/react/router/Types.hx
@@ -11,8 +11,8 @@ typedef Any = Dynamic;
 typedef HashHistory = Router<Any, Any>;
 typedef BrowserHistory = Router<Any, Any>;
 typedef RouteProps = RoutePropsOf<Any, Any>;
-typedef RoutePropsOfParams<P> = RoutePropsOf<P, Any>; 
-typedef RoutePropsOfQuery<Q> = RoutePropsOf<Any, Q>; 
+typedef RoutePropsOfParams<P> = RoutePropsOf<P, Any>;
+typedef RoutePropsOfQuery<Q> = RoutePropsOf<Any, Q>;
 
 typedef RoutePropsOf<P, Q> = {
 	route:Route<P, Q>,


### PR DESCRIPTION
I modernized the library due to it needing to be updated. By having ``@:js.import`` the library isn't just limited to pure ``create-react-app`` but could also work with modern versions of meta frameworks like Vite, Remix, or NextJS. I've contributed to the original haxe-react for the same reason.