### PR TITLE
Usable for versions 4.0.0 and above

### DIFF
--- a/src/react/router/BrowserRouter.hx
+++ b/src/react/router/BrowserRouter.hx
@@ -1,0 +1,12 @@
+package src.react.router;
+
+/*
+* Avaliable for versions 4.0.0 and above
+*/
+
+#if (jsImport)
+@:js.import('react-router-dom', 'BrowserRouter')
+#else
+@:jsRequire('react-router-dom', 'BrowserRouter')
+#end
+extern class BrowserRouter extends react.ReactComponent {}

--- a/src/react/router/HashRouter.hx
+++ b/src/react/router/HashRouter.hx
@@ -1,0 +1,12 @@
+package src.react.router;
+
+/*
+* Avaliable for versions 4.0.0 and above
+*/
+
+#if (jsImport)
+@:js.import('react-router-dom', 'HashRouter')
+#else
+@:jsRequire('react-router-dom', 'HashRouter')
+#end
+extern class HashRouter extends react.ReactComponent {}

--- a/src/react/router/Statics.hx
+++ b/src/react/router/Statics.hx
@@ -11,7 +11,4 @@ extern class Statics {
 	static public var hashHistory:HashHistory;
 	static public var browserHistory:BrowserHistory;
 	static public var withRouter:Dynamic->Dynamic;
-
-	static public function useLocation<Q>():Location<Q>; // Avaliable for versions 4.0.0 and above
-    static public function useHistory():HashHistory; // Avaliable for versions 4.0.0 and above
 }

--- a/src/react/router/Statics.hx
+++ b/src/react/router/Statics.hx
@@ -11,4 +11,7 @@ extern class Statics {
 	static public var hashHistory:HashHistory;
 	static public var browserHistory:BrowserHistory;
 	static public var withRouter:Dynamic->Dynamic;
+	
+	static public function useLocation<T>():T; // Avaliable for versions 4.0.0 and above
+	static public function useHistory<T>():T; // Avaliable for versions 4.0.0 and above
 }

--- a/src/react/router/Statics.hx
+++ b/src/react/router/Statics.hx
@@ -11,7 +11,7 @@ extern class Statics {
 	static public var hashHistory:HashHistory;
 	static public var browserHistory:BrowserHistory;
 	static public var withRouter:Dynamic->Dynamic;
-	
-	static public function useLocation<T>():T; // Avaliable for versions 4.0.0 and above
-	static public function useHistory<T>():T; // Avaliable for versions 4.0.0 and above
+
+	static public function useLocation<Q>():Location<Q>; // Avaliable for versions 4.0.0 and above
+    static public function useHistory():HashHistory; // Avaliable for versions 4.0.0 and above
 }

--- a/src/react/router/Types.hx
+++ b/src/react/router/Types.hx
@@ -31,12 +31,12 @@ typedef RoutePropsOf<P, Q> = {
 }
 
 private typedef Object = Any;
-@:enum
-private abstract Action(String) {
+#if haxe4 private enum #else @:enum private #end abstract Action(String) {
 	var Push = 'PUSH';
 	var Replace = 'REPLACE';
 	var Pop = 'POP';
 }
+
 private typedef Component = EitherType<Class<ReactComponent>, String>;
 private typedef EnterHook<P, Q> = RouterState<P, Q>->RedirectFunction<Q>->?Function->Any;
 private typedef Hash = String;

--- a/src/react/router/Types.hx
+++ b/src/react/router/Types.hx
@@ -14,6 +14,15 @@ typedef RouteProps = RoutePropsOf<Any, Any>;
 typedef RoutePropsOfParams<P> = RoutePropsOf<P, Any>;
 typedef RoutePropsOfQuery<Q> = RoutePropsOf<Any, Q>;
 
+typedef Location<Q> = {
+	pathname:Pathname,
+	search:QueryString,
+	query:Query<Q>,
+	state:LocationState,
+	action:Action,
+	key:LocationKey,
+};
+
 typedef RoutePropsOf<P, Q> = {
 	route:Route<P, Q>,
 	router:Router<P, Q>,
@@ -32,14 +41,6 @@ private typedef Component = EitherType<Class<ReactComponent>, String>;
 private typedef EnterHook<P, Q> = RouterState<P, Q>->RedirectFunction<Q>->?Function->Any;
 private typedef Hash = String;
 private typedef LeaveHook<P, Q> = RouterState<P, Q>->Any;
-private typedef Location<Q> = {
-	pathname:Pathname,
-	search:QueryString,
-	query:Query<Q>,
-	state:LocationState,
-	action:Action,
-	key:LocationKey,
-};
 private typedef LocationDescriptorObject<Q> = {
 	pathname:Pathname,
 	search:QueryString,


### PR DESCRIPTION
I implemented new classes and methods. The previous methods like ``browserHistory`` and ``hashHistory``were removed **react-router-dom** in version 4 and placed with ``BrowserRouter`` and ``HashRouter``.